### PR TITLE
feat(renovate): distinguish library and app npm dependency strategies

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -21,10 +21,19 @@
   ],
   "packageRules": [
     {
-      "description": "Use bump strategy for production dependencies to maintain existing range types",
+      "description": "Use replace strategy for library dependencies to preserve version ranges",
       "matchDepTypes": ["dependencies"],
       "matchManagers": ["npm"],
-      "rangeStrategy": "bump"
+      "matchFileNames": ["package.json"],
+      "matchJsonata": ["$.publishConfig"],
+      "rangeStrategy": "replace"
+    },
+    {
+      "description": "Pin application dependencies for reproducible production builds",
+      "matchDepTypes": ["dependencies"],
+      "matchManagers": ["npm"],
+      "matchJsonata": ["$.private = true and not($.publishConfig)"],
+      "rangeStrategy": "pin"
     },
     {
       "description": "Widen peer dependency ranges to support multiple versions",
@@ -85,6 +94,12 @@
       ],
       "automerge": false,
       "platformAutomerge": false
+    },
+    {
+      "description": "Trust our own shared actions repos — follow version tags without digest pinning",
+      "matchPackageNames": ["openmfp/gha", "openmfp/.github"],
+      "matchManagers": ["github-actions"],
+      "pinDigests": false
     },
     {
       "groupName": "Github Actions",


### PR DESCRIPTION
## Summary

- Replace the single `bump` range strategy for npm production dependencies with two explicit rules using `matchJsonata`:
  - **Libraries** (`publishConfig` present): `replace` strategy — preserves semver ranges (`^`/`~`), preventing forced exact versions for downstream consumers
  - **Applications** (`private: true`): `pin` strategy — exact versions for reproducible production builds
- Skip digest pinning for `openmfp/gha` and `openmfp/.github` GitHub Actions, since we trust our own shared workflow repos

Aligns with the [platform-mesh shared Renovate configuration](https://github.com/platform-mesh/.github/blob/main/renovate-config.json).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined automated dependency update rules to better preserve existing version range behavior for published packages while enabling deterministic updates for private dependencies.
  * Updated GitHub Actions dependency update settings to avoid digest pinning for relevant repositories, improving consistency of action version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->